### PR TITLE
feat: Use Joi for validating requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For licensing information, see the attached LICENSE file and the list of third-p
 
 ```json
 {
-  "backend": "<'staging' or 'production' or 'prod'>",
+  "backend": "<'prod'|'production'|'staging'>",
   "deviceName": "<string>",
   "email": "<string in email format>",
   "name": "<string>",
@@ -141,7 +141,7 @@ For licensing information, see the attached LICENSE file and the list of third-p
 ```json
 {
   "conversationId": "<string in UUID format>",
-  "payload": "<started|stopped>"
+  "payload": "<'started'|'stopped'>"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "@types/dotenv": "4.0.3",
     "@types/express": "4.11.1",
     "@types/helmet": "0.0.37",
+    "@types/joi": "13.0.8",
     "@types/node": "10.1.4",
     "@wireapp/core": "2.9.1",
     "@wireapp/lru-cache": "2.1.14",
@@ -11,8 +12,8 @@
     "compression": "1.7.2",
     "dotenv": "5.0.1",
     "express": "4.16.3",
-    "express-validator": "5.2.0",
     "helmet": "3.12.1",
+    "joi": "13.3.0",
     "pure-uuid": "1.5.2",
     "typescript": "2.8.3"
   },

--- a/src/main/middlewares/joiValidate.ts
+++ b/src/main/middlewares/joiValidate.ts
@@ -1,0 +1,43 @@
+/*
+ * Wire
+ * Copyright (C) 2018 Wire Swiss GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see http://www.gnu.org/licenses/.
+ *
+ */
+
+import * as Express from 'express';
+import * as Joi from 'joi';
+
+const joiValidate = (schema: Joi.SchemaLike) => (
+  req: Express.Request,
+  res: Express.Response,
+  next: Express.NextFunction
+): void => {
+  const {body, method} = req;
+
+  if (method === 'GET' || method === 'DELETE') {
+    return next();
+  }
+
+  const {error: joiError} = Joi.validate(body, schema);
+  if (joiError) {
+    res.status(422).json({error: `Validation error: ${joiError.message}}`});
+    return;
+  }
+
+  return next();
+};
+
+export default joiValidate;

--- a/src/main/routes/instance/assetRoutes.ts
+++ b/src/main/routes/instance/assetRoutes.ts
@@ -54,7 +54,6 @@ const assetRoutes = (instanceService: InstanceService): express.Router => {
     const {conversationId, data: base64Data, height, type, width}: ImageMessageRequest = req.body;
 
     const {error: joiError} = Joi.validate(req.body, joiSchema);
-
     if (joiError) {
       return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }

--- a/src/main/routes/instance/assetRoutes.ts
+++ b/src/main/routes/instance/assetRoutes.ts
@@ -19,7 +19,7 @@
 
 import {Image} from '@wireapp/core/dist/conversation/root';
 import * as express from 'express';
-import {check, validationResult} from 'express-validator/check';
+import * as Joi from 'joi';
 import InstanceService from '../../InstanceService';
 
 export interface ImageMessageRequest {
@@ -30,46 +30,53 @@ export interface ImageMessageRequest {
   width: number;
 }
 
+const joiSchema = {
+  conversationId: Joi.string()
+    .uuid()
+    .required(),
+  data: Joi.string()
+    .base64()
+    .required(),
+  height: Joi.number()
+    .min(1)
+    .required(),
+  type: Joi.string().required(),
+  width: Joi.number()
+    .min(1)
+    .required(),
+};
+
 const assetRoutes = (instanceService: InstanceService): express.Router => {
   const router = express.Router();
 
-  router.post(
-    '/api/v1/instance/:instanceId/sendImage',
-    [
-      check('conversationId').isUUID(),
-      check('data').isBase64(),
-      check('height').isInt(),
-      check('type').isMimeType(),
-      check('width').isInt(),
-    ],
-    async (req: express.Request, res: express.Response) => {
-      const {instanceId = ''}: {instanceId: string} = req.params;
-      const {conversationId, data: base64Data, height, type, width}: ImageMessageRequest = req.body;
+  router.post('/api/v1/instance/:instanceId/sendImage/?', async (req: express.Request, res: express.Response) => {
+    const {instanceId = ''}: {instanceId: string} = req.params;
+    const {conversationId, data: base64Data, height, type, width}: ImageMessageRequest = req.body;
 
-      const errors = validationResult(req);
-      if (!errors.isEmpty()) {
-        return res.status(422).json({errors: errors.mapped()});
-      }
+    const {error: joiError} = Joi.validate(req.body, joiSchema);
 
-      if (!instanceService.instanceExists(instanceId)) {
-        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
-      }
-
-      try {
-        const data = Buffer.from(base64Data, 'base64');
-        const image: Image = {data, height, type, width};
-        const messageId = await instanceService.sendImage(instanceId, conversationId, image);
-        const instanceName = instanceService.getInstance(instanceId).name;
-        return res.json({
-          instanceId,
-          messageId,
-          name: instanceName,
-        });
-      } catch (error) {
-        return res.status(500).json({error: error.message, stack: error.stack});
-      }
+    if (joiError) {
+      return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }
-  );
+
+    if (!instanceService.instanceExists(instanceId)) {
+      return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+    }
+
+    try {
+      const data = Buffer.from(base64Data, 'base64');
+      const image: Image = {data, height, type, width};
+      const messageId = await instanceService.sendImage(instanceId, conversationId, image);
+      const instanceName = instanceService.getInstance(instanceId).name;
+      return res.json({
+        instanceId,
+        messageId,
+        name: instanceName,
+      });
+    } catch (error) {
+      return res.status(500).json({error: error.message, stack: error.stack});
+    }
+  });
 
   return router;
 };

--- a/src/main/routes/instance/confirmationRoutes.ts
+++ b/src/main/routes/instance/confirmationRoutes.ts
@@ -43,7 +43,6 @@ const confirmationRoutes = (instanceService: InstanceService): express.Router =>
     const {conversationId, messageId}: ConfirmationMessageRequest = req.body;
 
     const {error: joiError} = Joi.validate(req.body, joiSchema);
-
     if (joiError) {
       return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }

--- a/src/main/routes/instance/confirmationRoutes.ts
+++ b/src/main/routes/instance/confirmationRoutes.ts
@@ -20,47 +20,45 @@
 import * as express from 'express';
 import * as Joi from 'joi';
 import InstanceService from '../../InstanceService';
+import joiValidate from '../../middlewares/joiValidate';
 
 export interface ConfirmationMessageRequest {
   conversationId: string;
   messageId: string;
 }
 
-const joiSchema = {
-  conversationId: Joi.string()
-    .uuid()
-    .required(),
-  messageId: Joi.string()
-    .uuid()
-    .required(),
-};
-
 const confirmationRoutes = (instanceService: InstanceService): express.Router => {
   const router = express.Router();
 
-  router.post('/api/v1/instance/:instanceId/sendConfirmation', async (req: express.Request, res: express.Response) => {
-    const {instanceId = ''}: {instanceId: string} = req.params;
-    const {conversationId, messageId}: ConfirmationMessageRequest = req.body;
+  router.post(
+    '/api/v1/instance/:instanceId/sendConfirmation',
+    joiValidate({
+      conversationId: Joi.string()
+        .uuid()
+        .required(),
+      messageId: Joi.string()
+        .uuid()
+        .required(),
+    }),
+    async (req: express.Request, res: express.Response) => {
+      const {instanceId = ''}: {instanceId: string} = req.params;
+      const {conversationId, messageId}: ConfirmationMessageRequest = req.body;
 
-    const {error: joiError} = Joi.validate(req.body, joiSchema);
-    if (joiError) {
-      return res.status(422).json({error: `Validation error: ${joiError.message}}`});
-    }
+      if (!instanceService.instanceExists(instanceId)) {
+        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      }
 
-    if (!instanceService.instanceExists(instanceId)) {
-      return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      try {
+        const instanceName = await instanceService.sendConfirmation(instanceId, conversationId, messageId);
+        return res.json({
+          instanceId,
+          name: instanceName,
+        });
+      } catch (error) {
+        return res.status(500).json({error: error.message, stack: error.stack});
+      }
     }
-
-    try {
-      const instanceName = await instanceService.sendConfirmation(instanceId, conversationId, messageId);
-      return res.json({
-        instanceId,
-        name: instanceName,
-      });
-    } catch (error) {
-      return res.status(500).json({error: error.message, stack: error.stack});
-    }
-  });
+  );
 
   return router;
 };

--- a/src/main/routes/instance/conversationRoutes.ts
+++ b/src/main/routes/instance/conversationRoutes.ts
@@ -19,8 +19,8 @@
 
 import * as express from 'express';
 import * as Joi from 'joi';
-
 import InstanceService from '../../InstanceService';
+import joiValidate from '../../middlewares/joiValidate';
 
 export interface MessageRequest {
   conversationId: string;
@@ -36,74 +36,68 @@ export interface MessageUpdateRequest {
 const conversationRoutes = (instanceService: InstanceService): express.Router => {
   const router = express.Router();
 
-  router.post('/api/v1/instance/:instanceId/sendText', async (req: express.Request, res: express.Response) => {
-    const {instanceId = ''}: {instanceId: string} = req.params;
-    const {conversationId, payload}: MessageRequest = req.body;
-
-    const joiSchema = {
+  router.post(
+    '/api/v1/instance/:instanceId/sendText',
+    joiValidate({
       conversationId: Joi.string()
         .uuid()
         .required(),
       payload: Joi.string().required(),
-    };
-    const {error: joiError} = Joi.validate(req.body, joiSchema);
-    if (joiError) {
-      return res.status(422).json({error: `Validation error: ${joiError.message}}`});
+    }),
+    async (req: express.Request, res: express.Response) => {
+      const {instanceId = ''}: {instanceId: string} = req.params;
+      const {conversationId, payload}: MessageRequest = req.body;
+
+      if (!instanceService.instanceExists(instanceId)) {
+        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      }
+
+      try {
+        const messageId = await instanceService.sendText(instanceId, conversationId, payload);
+        const instanceName = instanceService.getInstance(instanceId).name;
+        return res.json({
+          instanceId,
+          messageId,
+          name: instanceName,
+        });
+      } catch (error) {
+        return res.status(500).json({error: error.message, stack: error.stack});
+      }
     }
+  );
 
-    if (!instanceService.instanceExists(instanceId)) {
-      return res.status(400).json({error: `Instance "${instanceId}" not found.`});
-    }
-
-    try {
-      const messageId = await instanceService.sendText(instanceId, conversationId, payload);
-      const instanceName = instanceService.getInstance(instanceId).name;
-      return res.json({
-        instanceId,
-        messageId,
-        name: instanceName,
-      });
-    } catch (error) {
-      return res.status(500).json({error: error.message, stack: error.stack});
-    }
-  });
-
-  router.post('/api/v1/instance/:instanceId/sendPing', async (req: express.Request, res: express.Response) => {
-    const {instanceId = ''}: {instanceId: string} = req.params;
-    const {conversationId}: MessageRequest = req.body;
-
-    const joiSchema = {
+  router.post(
+    '/api/v1/instance/:instanceId/sendPing',
+    joiValidate({
       conversationId: Joi.string()
         .uuid()
         .required(),
-    };
-    const {error: joiError} = Joi.validate(req.body, joiSchema);
-    if (joiError) {
-      return res.status(422).json({error: `Validation error: ${joiError.message}}`});
+    }),
+    async (req: express.Request, res: express.Response) => {
+      const {instanceId = ''}: {instanceId: string} = req.params;
+      const {conversationId}: MessageRequest = req.body;
+
+      if (!instanceService.instanceExists(instanceId)) {
+        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      }
+
+      try {
+        const messageId = await instanceService.sendPing(instanceId, conversationId);
+        const instanceName = instanceService.getInstance(instanceId).name;
+        return res.json({
+          instanceId,
+          messageId,
+          name: instanceName,
+        });
+      } catch (error) {
+        return res.status(500).json({error: error.message, stack: error.stack});
+      }
     }
+  );
 
-    if (!instanceService.instanceExists(instanceId)) {
-      return res.status(400).json({error: `Instance "${instanceId}" not found.`});
-    }
-
-    try {
-      const messageId = await instanceService.sendPing(instanceId, conversationId);
-      const instanceName = instanceService.getInstance(instanceId).name;
-      return res.json({
-        instanceId,
-        messageId,
-        name: instanceName,
-      });
-    } catch (error) {
-      return res.status(500).json({error: error.message, stack: error.stack});
-    }
-  });
-
-  router.post('/api/v1/instance/:instanceId/updateText', async (req: express.Request, res: express.Response) => {
-    const {instanceId = ''}: {instanceId: string} = req.params;
-    const {conversationId, firstMessageId, payload}: MessageUpdateRequest = req.body;
-
-    const joiSchema = {
+  router.post(
+    '/api/v1/instance/:instanceId/updateText',
+    joiValidate({
       conversationId: Joi.string()
         .uuid()
         .required(),
@@ -111,28 +105,28 @@ const conversationRoutes = (instanceService: InstanceService): express.Router =>
         .uuid()
         .required(),
       payload: Joi.string().required(),
-    };
-    const {error: joiError} = Joi.validate(req.body, joiSchema);
-    if (joiError) {
-      return res.status(422).json({error: `Validation error: ${joiError.message}}`});
-    }
+    }),
+    async (req: express.Request, res: express.Response) => {
+      const {instanceId = ''}: {instanceId: string} = req.params;
+      const {conversationId, firstMessageId, payload}: MessageUpdateRequest = req.body;
 
-    if (!instanceService.instanceExists(instanceId)) {
-      return res.status(400).json({error: `Instance "${instanceId}" not found.`});
-    }
+      if (!instanceService.instanceExists(instanceId)) {
+        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      }
 
-    try {
-      const messageId = await instanceService.updateText(instanceId, conversationId, firstMessageId, payload);
-      const instanceName = instanceService.getInstance(instanceId).name;
-      return res.json({
-        instanceId,
-        messageId,
-        name: instanceName,
-      });
-    } catch (error) {
-      return res.status(500).json({error: error.message, stack: error.stack});
+      try {
+        const messageId = await instanceService.updateText(instanceId, conversationId, firstMessageId, payload);
+        const instanceName = instanceService.getInstance(instanceId).name;
+        return res.json({
+          instanceId,
+          messageId,
+          name: instanceName,
+        });
+      } catch (error) {
+        return res.status(500).json({error: error.message, stack: error.stack});
+      }
     }
-  });
+  );
 
   return router;
 };

--- a/src/main/routes/instance/conversationRoutes.ts
+++ b/src/main/routes/instance/conversationRoutes.ts
@@ -47,7 +47,6 @@ const conversationRoutes = (instanceService: InstanceService): express.Router =>
       payload: Joi.string().required(),
     };
     const {error: joiError} = Joi.validate(req.body, joiSchema);
-
     if (joiError) {
       return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }
@@ -79,7 +78,6 @@ const conversationRoutes = (instanceService: InstanceService): express.Router =>
         .required(),
     };
     const {error: joiError} = Joi.validate(req.body, joiSchema);
-
     if (joiError) {
       return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }
@@ -115,7 +113,6 @@ const conversationRoutes = (instanceService: InstanceService): express.Router =>
       payload: Joi.string().required(),
     };
     const {error: joiError} = Joi.validate(req.body, joiSchema);
-
     if (joiError) {
       return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }

--- a/src/main/routes/instance/mainRoutes.ts
+++ b/src/main/routes/instance/mainRoutes.ts
@@ -32,8 +32,7 @@ export interface InstanceRequest {
 
 const joiSchema = {
   backend: Joi.string()
-    .regex(/^(prod(uction)?|staging)$/)
-    .description('Should be "prod", "production" or "staging".')
+    .valid(['prod', 'production', 'staging'])
     .required(),
   email: Joi.string()
     .email()

--- a/src/main/routes/instance/mainRoutes.ts
+++ b/src/main/routes/instance/mainRoutes.ts
@@ -46,8 +46,8 @@ const mainRoutes = (instanceService: InstanceService): express.Router => {
 
   router.put('/api/v1/instance/?', async (req: express.Request, res: express.Response) => {
     const {backend, deviceName, email, name: instanceName, password}: InstanceRequest = req.body;
-    const {error: joiError} = Joi.validate(req.body, joiSchema);
 
+    const {error: joiError} = Joi.validate(req.body, joiSchema);
     if (joiError) {
       return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }

--- a/src/main/routes/instance/typingRoutes.ts
+++ b/src/main/routes/instance/typingRoutes.ts
@@ -20,47 +20,45 @@
 import * as express from 'express';
 import * as Joi from 'joi';
 import InstanceService from '../../InstanceService';
+import joiValidate from '../../middlewares/joiValidate';
 
 export interface TypingMessageRequest {
   conversationId: string;
   payload: 'started' | 'stopped';
 }
 
-const joiSchema = {
-  conversationId: Joi.string()
-    .uuid()
-    .required(),
-  payload: Joi.string()
-    .regex(/^(started|stopped)$/)
-    .required(),
-};
-
 const typingRoutes = (instanceService: InstanceService): express.Router => {
   const router = express.Router();
 
-  router.post('/api/v1/instance/:instanceId/typing', async (req: express.Request, res: express.Response) => {
-    const {instanceId = ''}: {instanceId: string} = req.params;
-    const {conversationId, payload}: TypingMessageRequest = req.body;
+  router.post(
+    '/api/v1/instance/:instanceId/typing',
+    joiValidate({
+      conversationId: Joi.string()
+        .uuid()
+        .required(),
+      payload: Joi.string()
+        .valid(['started', 'stopped'])
+        .required(),
+    }),
+    async (req: express.Request, res: express.Response) => {
+      const {instanceId = ''}: {instanceId: string} = req.params;
+      const {conversationId, payload}: TypingMessageRequest = req.body;
 
-    const {error: joiError} = Joi.validate(req.body, joiSchema);
-    if (joiError) {
-      return res.status(422).json({error: `Validation error: ${joiError.message}}`});
-    }
+      if (!instanceService.instanceExists(instanceId)) {
+        return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      }
 
-    if (!instanceService.instanceExists(instanceId)) {
-      return res.status(400).json({error: `Instance "${instanceId}" not found.`});
+      try {
+        const instanceName = await instanceService.sendTyping(instanceId, conversationId, payload);
+        return res.json({
+          instanceId,
+          name: instanceName,
+        });
+      } catch (error) {
+        return res.status(500).json({error: error.message, stack: error.stack});
+      }
     }
-
-    try {
-      const instanceName = await instanceService.sendTyping(instanceId, conversationId, payload);
-      return res.json({
-        instanceId,
-        name: instanceName,
-      });
-    } catch (error) {
-      return res.status(500).json({error: error.message, stack: error.stack});
-    }
-  });
+  );
 
   return router;
 };

--- a/src/main/routes/instance/typingRoutes.ts
+++ b/src/main/routes/instance/typingRoutes.ts
@@ -43,7 +43,6 @@ const typingRoutes = (instanceService: InstanceService): express.Router => {
     const {conversationId, payload}: TypingMessageRequest = req.body;
 
     const {error: joiError} = Joi.validate(req.body, joiSchema);
-
     if (joiError) {
       return res.status(422).json({error: `Validation error: ${joiError.message}}`});
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -141,6 +141,10 @@
   dependencies:
     "@types/express" "*"
 
+"@types/joi@13.0.8":
+  version "13.0.8"
+  resolved "https://registry.yarnpkg.com/@types/joi/-/joi-13.0.8.tgz#224d5da224036f0c15b35e6980ba9de63b8ea374"
+
 "@types/long@^3.0.32":
   version "3.0.32"
   resolved "https://registry.yarnpkg.com/@types/long/-/long-3.0.32.tgz#f4e5af31e9e9b196d8e5fca8a5e2e20aa3d60b69"
@@ -942,13 +946,6 @@ expect@^22.4.0:
     jest-message-util "^22.4.3"
     jest-regex-util "^22.4.3"
 
-express-validator@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/express-validator/-/express-validator-5.2.0.tgz#28f068fc676022acfe182c97fd9e780f9ffb26f6"
-  dependencies:
-    lodash "^4.17.10"
-    validator "^10.1.0"
-
 express@4.16.3:
   version "4.16.3"
   resolved "https://registry.yarnpkg.com/express/-/express-4.16.3.tgz#6af8a502350db3246ecc4becf6b5a34d22f7ed53"
@@ -1273,6 +1270,10 @@ hide-powered-by@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/hide-powered-by/-/hide-powered-by-1.0.0.tgz#4a85ad65881f62857fc70af7174a1184dccce32b"
 
+hoek@5.x.x:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/hoek/-/hoek-5.0.3.tgz#b71d40d943d0a95da01956b547f83c4a5b4a34ac"
+
 hpkp@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/hpkp/-/hpkp-2.0.0.tgz#10e142264e76215a5d30c44ec43de64dee6d1672"
@@ -1550,6 +1551,12 @@ isarray@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
+isemail@3.x.x:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/isemail/-/isemail-3.1.2.tgz#937cf919002077999a73ea8b1951d590e84e01dd"
+  dependencies:
+    punycode "2.x.x"
+
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -1697,6 +1704,14 @@ jest-validate@^22.4.0, jest-validate@^22.4.4:
     jest-get-type "^22.1.0"
     leven "^2.1.0"
     pretty-format "^22.4.0"
+
+joi@13.3.0:
+  version "13.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-13.3.0.tgz#4defd4333b539c5d10e444ab44f5a5583480f17c"
+  dependencies:
+    hoek "5.x.x"
+    isemail "3.x.x"
+    topo "3.x.x"
 
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
@@ -1903,7 +1918,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.5:
+lodash@^4.13.1, lodash@^4.17.5:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -2322,13 +2337,13 @@ pseudomap@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
 
+punycode@2.x.x, punycode@^2.1.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
+
 punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
-
-punycode@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
 
 pure-uuid@1.5.2:
   version "1.5.2"
@@ -2777,6 +2792,12 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
+topo@3.x.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/topo/-/topo-3.0.0.tgz#37e48c330efeac784538e0acd3e62ca5e231fe7a"
+  dependencies:
+    hoek "5.x.x"
+
 tough-cookie@2.3.4, tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.3:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.3.4.tgz#ec60cee38ac675063ffc97a5c18970578ee83655"
@@ -2903,10 +2924,6 @@ utils-merge@1.0.1:
 uuid@^3.1.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.2.1.tgz#12c528bb9d58d0b9265d9a2f6f0fe8be17ff1f14"
-
-validator@^10.1.0:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-10.2.0.tgz#61d6b10c3d5c9f368c75c2ce8ca2b792522eaafa"
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Fixes #4.
- `express-validator` was replaced with `Joi`.
- all other changes were made by prettier.